### PR TITLE
Fix Travis deployment from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,16 @@ cache:
     - "node_modules"
 
 install:
-    - yarn install
+  - npm install -g vsce
+  - npm install
 
-jobs:
-  include:
-    - stage: build
-      script:
-        - yarn lint
-        - yarn test
-        - yarn build
-    - stage: deploy
-      script:
-        - yarn deploy
+script:
+  - npm run lint
+  - vsce package
+
+deploy:
+  - provider: script  
+    script: vsce publish -p $AZURE_PAT
+    skip_cleanup: true
+    on:
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ install:
 
 script:
   - npm run lint
-  - vsce package
+  # npm ls command is broken causing vsce to fail, see:
+  # https://github.com/Microsoft/vscode-vsce/issues/246
+  - vsce package --yarn
 
 deploy:
   - provider: script  


### PR DESCRIPTION
The failure was due to the bug in npm, described on vsce at https://github.com/Microsoft/vscode-vsce/issues/246. Fixed by using `--yarn` flag.