### PR TITLE
feat(pm2-monit): Add global pm2 monit command via terminal utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
                     "when": "view == pm2-processes",
                     "command": "pm2.stopAll",
                     "group": "pm2"
+                },
+                {
+                    "when": "view == pm2-processes",
+                    "command": "pm2.monit",
+                    "group": "pm2"
                 }
             ]
         },
@@ -123,6 +128,11 @@
             {
                 "command": "pm2.refresh",
                 "title": "Refresh List",
+                "category": "pm2.container"
+            },
+            {
+                "command": "pm2.monit",
+                "title": "Processes: Monitor",
                 "category": "pm2.container"
             },
             {

--- a/src/contributions/commands.ts
+++ b/src/contributions/commands.ts
@@ -18,6 +18,10 @@ export const registerCommands = (pm2: PM2) => {
         item.stop();
     });
 
+    vscode.commands.registerCommand("pm2.monit", () => {
+        pm2.monit();
+    });
+
     vscode.commands.registerCommand("pm2.logsAll", () => {
         pm2.logs();
     });

--- a/src/model/pm2.ts
+++ b/src/model/pm2.ts
@@ -51,12 +51,13 @@ export class PM2
         this._isDisposed = true;
     }
 
+    monit() {
+        util.sendTerminalCommand("pm2 monit");
+    }
+
     logs(process?: nodePm2.ProcessDescription) {
-        const terminal = vscode.window.createTerminal("pm2");
-        terminal.sendText(
-            "pm2 logs " + (process && process.name ? process.name : "")
-        );
-        terminal.show();
+        const command = "pm2 logs " + (process && process.name ? process.name : "");
+        util.sendTerminalCommand(command);
     }
 
     reloadAll() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,4 +37,4 @@ export const sendTerminalCommand = (command: string, show: boolean = true) => {
     const terminal = vscode.window.createTerminal("pm2");
     terminal.sendText(command);
     if (show) terminal.show();
-}
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -32,3 +32,9 @@ export const refresher = ({
     !skipIf() && fn();
     return setTimeout(refresher({ fn, interval, skipIf }), interval());
 };
+
+export const sendTerminalCommand = (command: string, show: boolean = true) => {
+    const terminal = vscode.window.createTerminal("pm2");
+    terminal.sendText(command);
+    if (show) terminal.show();
+}


### PR DESCRIPTION
Feature:
- Add global `Processes: Monitor` option that launches `pm2 monit` in the terminal. 
Feature doc: https://pm2.io/doc/en/runtime/guide/process-management/#local-monitoring

Util:
- Refactored terminal send text into a function that is re-usable. Replaced usage for global logs and monit function.

Closes https://github.com/alsiola/pm2-explorer/issues/18
FYI @alsiola 