### PR TITLE
feat(pm2-flush): Add global flush logs option

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
                     "when": "view == pm2-processes",
                     "command": "pm2.stopAll",
                     "group": "pm2"
+                },
+                {
+                    "when": "view == pm2-processes",
+                    "command": "pm2.monit",
+                    "group": "pm2"
                 }
             ]
         },
@@ -123,6 +128,11 @@
             {
                 "command": "pm2.refresh",
                 "title": "Refresh List",
+                "category": "pm2.container"
+            },
+            {
+                "command": "pm2.monit",
+                "title": "Processes: Monitor",
                 "category": "pm2.container"
             },
             {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
                     "when": "view == pm2-processes",
                     "command": "pm2.monit",
                     "group": "pm2"
+                },
+                {
+                    "when": "view == pm2-processes",
+                    "command": "pm2.flushLogs",
+                    "group": "pm2"
                 }
             ]
         },
@@ -122,7 +127,12 @@
             },
             {
                 "command": "pm2.logsAll",
-                "title": "Processes: Logs",
+                "title": "Processes: View Logs",
+                "category": "pm2.container"
+            },
+            {
+                "command": "pm2.flushLogs",
+                "title": "Processes: Flush Logs",
                 "category": "pm2.container"
             },
             {

--- a/src/contributions/commands.ts
+++ b/src/contributions/commands.ts
@@ -18,6 +18,10 @@ export const registerCommands = (pm2: PM2) => {
         item.stop();
     });
 
+    vscode.commands.registerCommand("pm2.monit", () => {
+        pm2.monit();
+    });
+
     vscode.commands.registerCommand("pm2.logsAll", () => {
         pm2.logs();
     });

--- a/src/contributions/commands.ts
+++ b/src/contributions/commands.ts
@@ -22,6 +22,10 @@ export const registerCommands = (pm2: PM2) => {
         pm2.monit();
     });
 
+    vscode.commands.registerCommand("pm2.flushLogs", () => {
+        pm2.flushLogs();
+    });
+
     vscode.commands.registerCommand("pm2.logsAll", () => {
         pm2.logs();
     });

--- a/src/model/pm2.ts
+++ b/src/model/pm2.ts
@@ -51,12 +51,13 @@ export class PM2
         this._isDisposed = true;
     }
 
+    monit() {
+        util.sendTerminalCommand("pm2 monit");
+    }
+
     logs(process?: nodePm2.ProcessDescription) {
-        const terminal = vscode.window.createTerminal("pm2");
-        terminal.sendText(
-            "pm2 logs " + (process && process.name ? process.name : "")
-        );
-        terminal.show();
+        const command = "pm2 logs " + (process && process.name ? process.name : "");
+        util.sendTerminalCommand(command);
     }
 
     reloadAll() {

--- a/src/model/pm2.ts
+++ b/src/model/pm2.ts
@@ -54,6 +54,10 @@ export class PM2
     monit() {
         util.sendTerminalCommand("pm2 monit");
     }
+    
+    flushLogs() {
+        util.sendTerminalCommand("pm2 flush");
+    }
 
     logs(process?: nodePm2.ProcessDescription) {
         const command = "pm2 logs " + (process && process.name ? process.name : "");

--- a/src/util.ts
+++ b/src/util.ts
@@ -32,3 +32,9 @@ export const refresher = ({
     !skipIf() && fn();
     return setTimeout(refresher({ fn, interval, skipIf }), interval());
 };
+
+export const sendTerminalCommand = (command: string, show: boolean = true) => {
+    const terminal = vscode.window.createTerminal("pm2");
+    terminal.sendText(command);
+    if (show) terminal.show();
+}


### PR DESCRIPTION
**This PR sits on top of https://github.com/alsiola/pm2-explorer/pull/24. So please merge that first!**

Feature:
- Add global flush logs option
- Feature link: https://pm2.io/doc/en/runtime/guide/log-management/#log-files

Note(s):
- No other process specific log features available at this time

Closes https://github.com/alsiola/pm2-explorer/issues/17
FYI @alsiola 
