### PR TITLE
Send terminal text with quoted process name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pm2-explorer",
-    "version": "0.0.1",
+    "version": "0.0.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/model/pm2.ts
+++ b/src/model/pm2.ts
@@ -54,7 +54,7 @@ export class PM2
     logs(process?: nodePm2.ProcessDescription) {
         const terminal = vscode.window.createTerminal("pm2");
         terminal.sendText(
-            "pm2 logs " + (process && process.name ? process.name : "")
+            `pm2 logs '${process && process.name ? process.name : ""}'`
         );
         terminal.show();
     }


### PR DESCRIPTION
Resolves #26 - issue with logs when process name contains whitespace